### PR TITLE
Add rollout docker-io-ci4rail-colibri-mender-v1-0-6fd933d1-16ed-4399-943d-a54d310fba6b definition

### DIFF
--- a/releases/kaesebrot/rollouts/docker-io-ci4rail-colibri-mender-v1-0-6fd933d1-16ed-4399-943d-a54d310fba6b/catalog-info.yaml
+++ b/releases/kaesebrot/rollouts/docker-io-ci4rail-colibri-mender-v1-0-6fd933d1-16ed-4399-943d-a54d310fba6b/catalog-info.yaml
@@ -1,0 +1,17 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: docker-io-ci4rail-colibri-mender-v1-0-6fd933d1-16ed-4399-943d-a54d310fba6b
+  annotations:
+    'edgefarm.io/cluster': default
+    'edgefarm.io/release-image': docker.io/ci4rail/colibri-mender:v1.0
+  links:
+    - url: https://www.ci4rail.com
+      title: Ci4Rail Website
+      icon: backstage
+spec:
+  type: Rollout
+  owner: default/MBeer2605
+  lifecycle: production
+  system: system:default/demo-colibri
+  dependsOn: ['component:default/kaesebrot']

--- a/releases/kaesebrot/rollouts/docker-io-ci4rail-colibri-mender-v1-0-6fd933d1-16ed-4399-943d-a54d310fba6b/manifests/mender.yaml
+++ b/releases/kaesebrot/rollouts/docker-io-ci4rail-colibri-mender-v1-0-6fd933d1-16ed-4399-943d-a54d310fba6b/manifests/mender.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: upgrade.cattle.io/v1
+kind: Plan
+metadata:
+  name: docker-io-ci4rail-colibri-mender-v1-0-6fd933d1-16ed-4399-943d-a54d310fba6b
+  namespace: system-upgrade
+spec:
+  concurrency: 1
+  version: 
+  nodeSelector:
+    matchExpressions:
+      - {
+          key: kubernetes.io/hostname,
+          operator: In,
+          values: ['colibri'],
+        }
+  serviceAccountName: system-upgrade
+  drain:
+    force: false
+    disableEviction: true
+  secrets:
+    - name: mender-upgrade
+      path: /secrets/mender
+  tolerations:
+    - key: 'edgefarm.io'
+      operator: 'Exists'
+      effect: 'NoSchedule'
+  upgrade:
+    image: 'docker.io/ci4rail/colibri-mender:v1.0'
+    volumes:
+      - name: usr-share-mender
+        source: /usr/share/mender
+        destination: /usr/share/mender
+      - name: var-lib-mender
+        source: /var/lib/mender
+        destination: /var/lib/mender
+      - name: etc-mender
+        source: /etc/mender
+        destination: /etc/mender
+      - name: usr-bin-grub-mender-grubenv-print
+        source: /usr/bin/grub-mender-grubenv-print
+        destination: /usr/bin/grub-mender-grubenv-print
+      - name: usr-bin-grub-mender-grubenv-set
+        source: /usr/bin/grub-mender-grubenv-set
+        destination: /usr/bin/grub-mender-grubenv-set
+      - name: boot-efi
+        source: /boot/efi
+        destination: /boot/efi
+      - name: proc-sys-kernel-sysrq
+        source: /proc/sysrq-trigger
+        destination: /sysrq-trigger
+      - name: data-system-upgrade
+        source: /data/system-upgrade
+        destination: /data/system-upgrade
+    command: ["sh", "/secrets/mender/upgrade.sh"]


### PR DESCRIPTION
Adds a new rollout with name docker-io-ci4rail-colibri-mender-v1-0-6fd933d1-16ed-4399-943d-a54d310fba6b