### PR TITLE
Add firmware colibri-firmware-v1.1 definition

### DIFF
--- a/releases/colibri-firmware-v1.1/catalog-info.yaml
+++ b/releases/colibri-firmware-v1.1/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: colibri-firmware-v1.1
+  annotations:
+    'edgefarm.io/cluster': default
+    'edgefarm.io/release-image': 'ci4rail/colibri-mender:v1.1'
+spec:
+  type: Release
+  owner: default/KlausPopp
+  lifecycle: production
+  system: system:default/demo-colibri


### PR DESCRIPTION
Adds a new firmware with name colibri-firmware-v1.1