### PR TITLE
Add firmware ac100-apt definition

### DIFF
--- a/releases/ac100-apt/catalog-info.yaml
+++ b/releases/ac100-apt/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ac100-apt
+  annotations:
+    'edgefarm.io/cluster': default
+    'edgefarm.io/release-image': 'ubuntu:22.04'
+spec:
+  type: Release
+  owner: default/KlausPopp
+  lifecycle: production
+  system: system:default/demo-colibri


### PR DESCRIPTION
Adds a new firmware with name ac100-apt