### PR TITLE
Add rollout ubuntu-22-04-5bbe6 definition

### DIFF
--- a/releases/ac100-apt/rollouts/ubuntu-22-04-5bbe6/catalog-info.yaml
+++ b/releases/ac100-apt/rollouts/ubuntu-22-04-5bbe6/catalog-info.yaml
@@ -1,0 +1,17 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ubuntu-22-04-5bbe6
+  annotations:
+    'edgefarm.io/cluster': default
+    'edgefarm.io/release-image': ubuntu:22.04
+  links:
+    - url: https://www.ci4rail.com
+      title: Ci4Rail Website
+      icon: backstage
+spec:
+  type: Rollout
+  owner: default/KlausPopp
+  lifecycle: production
+  system: system:default/demo-colibri
+  dependsOn: ['component:default/ac100-apt']

--- a/releases/ac100-apt/rollouts/ubuntu-22-04-5bbe6/manifests/ubuntu.yaml
+++ b/releases/ac100-apt/rollouts/ubuntu-22-04-5bbe6/manifests/ubuntu.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ubuntu-22-04-5bbe6-secret
+  namespace: system-upgrade
+type: Opaque
+stringData:
+  upgrade.sh: |
+    #!/bin/sh
+    set -e
+    
+    # update package index
+    apt-get --assume-yes update
+    
+    # install packages
+    apt-get --assume-yes install \
+     bpytop
+---
+apiVersion: upgrade.cattle.io/v1
+kind: Plan
+metadata:
+   name: ubuntu-22-04-5bbe6
+  namespace: system-upgrade
+spec:
+  concurrency: 1
+  nodeSelector:
+    matchExpressions:
+      - {
+          key: kubernetes.io/hostname,
+          operator: In,
+          values: ['ac100a'],
+        }
+  serviceAccountName: system-upgrade
+  secrets:
+    - name: ubuntu-22-04-5bbe6-secret
+      path: /host/run/system-upgrade/secrets/ubuntu
+  drain:
+    force: false
+    disableEviction: true
+  version: "22.04"
+  tolerations:
+    - key: 'edgefarm.io'
+      operator: 'Exists'
+      effect: 'NoSchedule'
+  upgrade:
+    image: ubuntu:22.04
+    command: ["chroot", "/host"]
+    args: ["sh", "/run/system-upgrade/secrets/ubuntu/upgrade.sh"]
+

--- a/releases/ac100-apt/rollouts/ubuntu-22-04-5bbe6/manifests/ubuntu.yaml
+++ b/releases/ac100-apt/rollouts/ubuntu-22-04-5bbe6/manifests/ubuntu.yaml
@@ -21,7 +21,7 @@ apiVersion: upgrade.cattle.io/v1
 kind: Plan
 metadata:
    name: ubuntu-22-04-5bbe6
-  namespace: system-upgrade
+   namespace: system-upgrade
 spec:
   concurrency: 1
   nodeSelector:


### PR DESCRIPTION
Adds a new rollout with name ubuntu-22-04-5bbe6