### PR TITLE
Add rollout ubuntu-22-04-5bbe6 definition

### DIFF
--- a/releases/ac100-apt/rollouts/ubuntu-22-04-5bbe6/catalog-info.yaml
+++ b/releases/ac100-apt/rollouts/ubuntu-22-04-5bbe6/catalog-info.yaml
@@ -11,7 +11,7 @@ metadata:
       icon: backstage
 spec:
   type: Rollout
-  owner: default/KlausPopp
+  owner: default/batthebee
   lifecycle: production
   system: system:default/demo-colibri
   dependsOn: ['component:default/ac100-apt']

--- a/releases/ac100-apt/rollouts/ubuntu-22-04-5bbe6/manifests/ubuntu.yaml
+++ b/releases/ac100-apt/rollouts/ubuntu-22-04-5bbe6/manifests/ubuntu.yaml
@@ -10,18 +10,26 @@ stringData:
     #!/bin/sh
     set -e
     
+    # package versions
+    curl=7.58.0-2ubuntu3.14
+    openssl=1.1.1-1ubuntu2.1~18.04.13
+    
     # update package index
     apt-get --assume-yes update
     
     # install packages
     apt-get --assume-yes install \
-     htop
+      curl=$(curl) \
+      libcurl4=$(curl) \
+      libssl1.1=$(openssl) \
+      openssl=$(openssl)
+    
 ---
 apiVersion: upgrade.cattle.io/v1
 kind: Plan
 metadata:
-   name: ubuntu-22-04-5bbe6
-   namespace: system-upgrade
+  name: ubuntu-22-04-5bbe6
+  namespace: system-upgrade
 spec:
   concurrency: 1
   nodeSelector:
@@ -35,9 +43,6 @@ spec:
   secrets:
     - name: ubuntu-22-04-5bbe6-secret
       path: /host/run/system-upgrade/secrets/ubuntu
-  drain:
-    force: false
-    disableEviction: true
   version: "22.04"
   tolerations:
     - key: 'edgefarm.io'


### PR DESCRIPTION
Adds a new rollout with name ubuntu-22-04-5bbe6